### PR TITLE
Using log4j version from properties instead.

### DIFF
--- a/common/network-shuffle/pom.xml
+++ b/common/network-shuffle/pom.xml
@@ -85,17 +85,17 @@
       <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.17.1</version>
+      <version>${log4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.17.1</version>
+      <version>${log4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-1.2-api</artifactId>
-      <version>2.17.1</version>
+      <version>${log4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
Using log4j version from properties instead.
This will help easily update to another version if 2.17.1 is found vulnerable.