### PR TITLE
Using log4j version from properties instead.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -577,20 +577,20 @@
         <scope>${hadoop.deps.scope}</scope>
       </dependency-->
       <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>2.17.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>2.17.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-1.2-api</artifactId>
-      <version>2.17.1</version>
-    </dependency>    
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+        <version>${log4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
+        <version>${log4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-1.2-api</artifactId>
+        <version>${log4j.version}</version>
+      </dependency>    
       <dependency>
         <groupId>com.ning</groupId>
         <artifactId>compress-lzf</artifactId>


### PR DESCRIPTION
Using log4j version from properties instead.
This will help easily update to another version if 2.17.1 is found vulnerable.